### PR TITLE
Updated setup.sh with stability and ease-of-use fixes

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -1,45 +1,43 @@
+IPFS_PATH=/opt/ipfs
+
 # Check if volume exists
-if [ ! -d "$1" ]; then
-  echo "Expected volume in $1, but it could not be found. Exiting"
-  exit 1
+if [ ! -d "$IPFS_PATH" ]; then
+  echo "Expected volume in $IPFS_PATH, but it could not be found. Attempting to create path now."
+  mkdir -p /opt/ipfs
 fi
+
+if [ ! -d "$IPFS_PATH" ]; then
+  echo "Path creation failed, exiting."
+  exit 1
+fi 
 
 # Download IPFS
 echo "Downloading IPFS"
 wget https://dist.ipfs.io/ipfs-update/v1.7.1/ipfs-update_v1.7.1_linux-amd64.tar.gz
-tar -xvzf ipfs-update_v1.7.1_linux-amd64.tar.gz
-cd ipfs-update || exit
-sudo bash install.sh
+tar -xvzf ipfs-update_v1.7.1_linux-amd64.tar.gz -c /opt/ipfs/ipfs-update_v1.7.1_linux-amd64 
+
+sudo bash /opt/ipfs/ipfs-update/install.sh
 ipfs-update --version
 ipfs-update install latest
 ipfs --version
 
 # Set up IPFS
 echo "Setting up IPFS daemon"
-export IPFS_PATH="$1"
+export IPFS_PATH="$IPFS_PATH"
 ipfs init --profile server
-echo "[Unit]
-Description=IPFS Daemon
 
-[Service]
-ExecStart=/usr/local/bin/ipfs daemon
-User=root
-Restart=always
-LimitNOFILE=10240
-Environment=\"IPFS_PATH=$1\"
-Restart=on-failure
-RestartSec=5s
+# Start IPFS daemon
+echo "Starting IPFS daemon"
+systemctl enable ipfs
+systemctl start ipfs
 
-[Install]
-WantedBy=multi-user.target" >>/etc/systemd/system/ipfs.service
-sudo systemctl daemon-reload
-sudo systemctl enable ipfs
-sudo systemctl start ipfs
-sleep 10
+echo "Sleeping for a few seconds..."
+sleep 5
 
 # Pin files
-echo "Pinning files"
 # Wanderers Metadata
+echo "Pinning metadata files, this will take about 60 seconds"
 ipfs pin add QmNnWrwfAbsnWvyTgGpaYLdh1oAkBR5B74MjwZh8stTL97 --progress
 # Wanderers Videos
+echo "Pinning MP4 files, this is likely to take 4+ hours - make sure your terminal window doesn't time out!"
 ipfs pin add QmWeXmth66wkCT5RYeBG9p1mnHgzAkTxoAtBdPy3CzE6o8 --progress


### PR DESCRIPTION
Hey Emerald, few notes on this PR. 

First of all, I know we had originally agreed to set this up through Docker; I've found that there are some difficulties with that setup that I'm still working through. Although I've made it work, I don't think it would be very friendly to someone who doesn't already know Docker/ Linux, and believe that for now, these updates to `setup.sh` are a little more user-friendly.

On the specific changes you see to the file below - I've made it so that you no longer need to include the directory path as an argument to the script, and simply set `/opt/ipfs` as a variable for the path, and make an attempt at creating that path if it doesn't already exist before exiting. If the path fails to auto-create, we still exit at that point. 

I also removed the attempt to `cd`, as I've never had good luck with that approach in bash scripts, and opted to use specific paths for the tar file download/ extraction. This has proven more stable in my testing. 

Lastly, you can simply `systemctl enable ipfs` and `systemctl start ipfs` now without needing to add anything to the unit file, so I've removed the unit file creation from the script. This may have been added in an IPFS update, but trying to append the values to the unit file was causing issues when I first ran the script since the same values were inserted into the unit file twice. 

I still hope to create a more user-friendly experience with Docker, but want to get a more stable script made for people in the meantime. Thank you for your time to review and help me with getting set up initially! 